### PR TITLE
Use XDG standard paths

### DIFF
--- a/src/FoilAuthModel.cpp
+++ b/src/FoilAuthModel.cpp
@@ -54,6 +54,7 @@
 #include <QDateTime>
 #include <QThreadPool>
 #include <QSharedPointer>
+#include <QStandardPaths>
 
 #include <unistd.h>
 #include <sys/stat.h>
@@ -72,8 +73,8 @@
 #define MAX_HEADERS             8
 
 // Directories relative to home
-#define FOIL_AUTH_DIR           "Documents/FoilAuth"
-#define FOIL_KEY_DIR            ".local/share/foil"
+#define FOIL_AUTH_DIR           "FoilAuth"
+#define FOIL_KEY_DIR            "foil"
 #define FOIL_KEY_FILE           "foil.key"
 
 #define INFO_FILE               ".info"
@@ -1029,8 +1030,8 @@ FoilAuthModel::Private::Private(FoilAuthModel* aParent) :
     iQueuedSignals(0),
     iFirstQueuedSignal(SignalCount),
     iFoilState(FoilKeyMissing),
-    iFoilDataDir(QDir::homePath() + "/" FOIL_AUTH_DIR),
-    iFoilKeyDir(QDir::homePath() + "/" FOIL_KEY_DIR),
+    iFoilDataDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/" FOIL_AUTH_DIR),
+    iFoilKeyDir(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/" FOIL_KEY_DIR),
     iFoilKeyFile(iFoilKeyDir + "/" + FOIL_KEY_FILE),
     iPrivateKey(NULL),
     iPublicKey(NULL),


### PR DESCRIPTION
In case the app were to get ported to other systems,
or if Sailfish added localized directory names (like desktop distros do)
or if anything similar were to happen.

Closes #9